### PR TITLE
Type doc fixes

### DIFF
--- a/src/Cart.php
+++ b/src/Cart.php
@@ -6,8 +6,8 @@ use Netflex\Support\ReactiveObject;
 
 /**
  * @property-read int $id
- * @property-read CartItem[] $items
- * @property-read ReservationItem[] $reservations
+ * @property-read CartItemCollection $items
+ * @property-read ReservationItemCollection $reservations
  * @property-read float $discount
  * @property-read float $tax
  * @property-read float $total

--- a/src/Order.php
+++ b/src/Order.php
@@ -30,9 +30,9 @@ use Netflex\Commerce\Traits\API\OrderAPI;
  * @property string $user_agent
  * @property-read Cart $cart
  * @property-read Payments $payments
- * @property-read Data[] $data
+ * @property-read Data $data
  * @property-read LogItemCollection $log
- * @property-read Checkout[] $checkout
+ * @property-read Checkout $checkout
  * @property-read DiscountItemCollection $discounts
  */
 class Order extends ReactiveObject


### PR DESCRIPTION
Fixes Cart property doc types.
The properties $items and $reservations were typed as arrays rather than the collections they actually were.

Fixes Order doc types
The properties $data and $checkout are not arrays, but Data and Checkout objects.